### PR TITLE
Setup for Linux and exceptions with non-numeric video devices fixed

### DIFF
--- a/cv2_enumerate_cameras/linux_backend.py
+++ b/cv2_enumerate_cameras/linux_backend.py
@@ -25,6 +25,8 @@ def read_line(*args):
 def cameras_generator(apiPreference):
     for path in glob.glob('/dev/video*'):
         device_name = os.path.basename(path)
+        if not device_name[5:].isdigit():
+            break
         index = int(device_name[5:])
         video_device_path = f'/sys/class/video4linux/{device_name}'
         usb_device_path = os.path.join(video_device_path, 'device')

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,5 @@ if system == 'Linux':
         version=get_version('cv2_enumerate_cameras/__init__.py'),
         package_dir={"": "."},
         packages=["cv2_enumerate_cameras"],
+        install_requires=["linuxpy"],
         ext_modules=[])

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,10 @@ if system == 'Windows':
     )
 
 if system == 'Linux':
-    setup()
+    setup(
+        name='cv2_enumerate_cameras',
+        description='Enumerate / List / Find / Detect / Search index for opencv VideoCapture.',
+        version=get_version('cv2_enumerate_cameras/__init__.py'),
+        package_dir={"": "."},
+        packages=["cv2_enumerate_cameras"],
+        ext_modules=[])


### PR DESCRIPTION
Package setup fields for Linux was empty and was an exception when non-numeric video device was finded (in my case it was "video-enc0" and "video-dec0")