### PR TITLE
Finding and checking video devices on Linux improved

### DIFF
--- a/cv2_enumerate_cameras/linux_backend.py
+++ b/cv2_enumerate_cameras/linux_backend.py
@@ -1,6 +1,6 @@
 from cv2_enumerate_cameras.camera_info import CameraInfo
 import os
-import glob
+from linuxpy.video.device import iter_video_capture_devices
 
 try:
     import cv2
@@ -23,7 +23,9 @@ def read_line(*args):
 
 
 def cameras_generator(apiPreference):
-    for path in glob.glob('/dev/video*'):
+    for device in iter_video_capture_devices():
+        path = device.PREFIX + str(device.index)
+        index = device.index
         # find device name and index
         device_name = os.path.basename(path)
         if not device_name[5:].isdigit():

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,5 @@ if system == 'Linux':
         version=get_version('cv2_enumerate_cameras/__init__.py'),
         package_dir={"": "."},
         packages=["cv2_enumerate_cameras"],
+        install_requires=["linuxpy"],
         ext_modules=[])


### PR DESCRIPTION
I understand that you previously wrote that you do not want to add third-party modules to the project. I tried to take the code from the linuxpy library and rewrite it, implement it in your package, but the module turned out to be too large and terrible in architecture.
Motivation: at the moment, your library finds 2 video devices for each physical device. One of the video devices is virtual and cannot be used. My code allows your library to return only physically available video devices on Linux, which solves the above problem