### PR TITLE
Fix port numbering in AVFoundation Backend

### DIFF
--- a/cv2_enumerate_cameras/macos_backend.py
+++ b/cv2_enumerate_cameras/macos_backend.py
@@ -22,13 +22,23 @@ def cameras_generator(apiPreference):
         AVFoundation.AVMediaTypeVideo
     )
 
-    for d in devs:
+    devs = devs.arrayByAddingObjectsFromArray_(
+        AVFoundation.AVCaptureDevice.devicesWithMediaType_(
+            AVFoundation.AVMediaTypeMuxed
+        )
+    )
+
+    devs = list(devs)
+
+    devs.sort(key=lambda d: d.uniqueID())
+
+    for i, d in enumerate(devs):
         model = str(d.modelID())
         vid_m = _VID_RE.search(model)
         pid_m = _PID_RE.search(model)
 
         yield CameraInfo(
-            index=d.position(),
+            index=i,
             name=d.localizedName(),
             path=None,  # macOS does not provide a path
             vid=int(vid_m.group(1)) if vid_m else None,


### PR DESCRIPTION
Hi there, thanks for a great package. I just found it yesterday, apparently right in time for AVFoundation backend support. I had an issue with this new feature, and found a fix for it - I hope the PR is appreciated. I matched the style of the surrounding code as best I could, but am open to any suggested changes. 

## My issue

Running `cv2_enumerate_cameras` on my Mac (M1 MBP, Sequoia 15.5), I got the following output:

```
Enumerate using CAP_ANY backend:
+-------+------------------------------+------+------+------+
| index |             name             | vid  | pid  | path |
+-------+------------------------------+------+------+------+
|  1200 |           FaceTime HD Camera |  --  |  --  |  --  |
|  1200 | FaceTime HD Camera (Display) | 05AC | 1112 |  --  |
|  1200 |                   USB Camera | 0C45 | 6366 |  --  |
+-------+------------------------------+------+------+------+
Enumerate using AVFOUNDATION backend:
+-------+------------------------------+------+------+------+
| index |             name             | vid  | pid  | path |
+-------+------------------------------+------+------+------+
|     0 |           FaceTime HD Camera |  --  |  --  |  --  |
|     0 | FaceTime HD Camera (Display) | 05AC | 1112 |  --  |
|     0 |                   USB Camera | 0C45 | 6366 |  --  |
+-------+------------------------------+------+------+------+
```
The issue here is that all of the indexes show up as 0, despite there being 3 cameras. Ideally, these would show up as the actual port number OpenCV uses, which seems supported by the README.

Looking into the code, it looks like the index is being set as `d.position()`, but this always returns 0 on OSX. The position enum from AVFoundation is Front, Back, and Other, so it appears to be intended for iOS devices. The [relevant documentation is here](https://developer.apple.com/documentation/avfoundation/avcapturedevice/position-swift.enum?language=objc).

## The fix

In order to get the proper ordering to match OpenCV, I looked at the relevant source code [here](https://github.com/opencv/opencv/blob/66e5fce9282fb2a9daaec9a79e0e7ed8bb01db06/modules/videoio/src/cap_avfoundation_mac.mm#L360).

To get the ordering, OpenCV gets devices with `AVMediaTypeVideo` and `AVMediaTypeMuxed`. cv2_enumerate_cameras was only getting `AVMediaTypeVideo` devices, so to preserve OpenCV's ordering I added Muxed devices as well. 

Then OpenCV sorts based on `d.uniqueID()`, so I sorted the device list based on that field as well. 

At this point, the list of devices from AVFoundation should exactly match the list OpenCV is indexing into with the camera number, so we can use the list index from our list as the index in the `CameraInfo` class and everything should work properly.

## Testing

Testing with my changes, I got the output:
```
+-------+------------------------------+------+------+------+
| index |             name             | vid  | pid  | path |
+-------+------------------------------+------+------+------+
|  1200 |                   USB Camera | 0C45 | 6366 |  --  |
|  1201 | FaceTime HD Camera (Display) | 05AC | 1112 |  --  |
|  1202 |           FaceTime HD Camera |  --  |  --  |  --  |
+-------+------------------------------+------+------+------+
Enumerate using 1200 backend:
+-------+------------------------------+------+------+------+
| index |             name             | vid  | pid  | path |
+-------+------------------------------+------+------+------+
|     0 |                   USB Camera | 0C45 | 6366 |  --  |
|     1 | FaceTime HD Camera (Display) | 05AC | 1112 |  --  |
|     2 |           FaceTime HD Camera |  --  |  --  |  --  |
+-------+------------------------------+------+------+------+
```

And when I iterate through the sorted device list and create a `cv2.videoCapture` object with the list index, it opens the correct camera.

I hope this has been helpful.