### PR TITLE
Deduplicate devices on linux

### DIFF
--- a/cv2_enumerate_cameras/linux_backend.py
+++ b/cv2_enumerate_cameras/linux_backend.py
@@ -38,7 +38,7 @@ def device_can_capture_video(device_name: str) -> bool:
     else:
         return True  # Device info returns no capabilities listed, assume it supports capture
 
-    for line in lines[search_index:]:
+    for line in lines[search_index + 1 :]:
         if 'Video Capture' in line:
             return True
         elif not line.startswith('\t\t'):


### PR DESCRIPTION
I finally got around to testing this package on Linux, and noticed there's a bug that duplicates cameras. The first camera is the actual video stream, and the second camera is listed as a video devices in `/dev/`, but only contains metadata for the other device. So you may have two devices listed, `/dev/video0` and `dev/video1`, but only one has an actual video stream. The reasoning for this is described by [this stack overflow post](https://unix.stackexchange.com/a/539573).

This causes an error using `cv2_enumerate_packages`, because it sometimes returns devices without video streams. Trying to instantiate a `cv2.VideoCapture` instance with the provided index will cause an error. This PR adds a check to make sure each returned camera has video capabilities.

## The Fix

Because this behavior isn't guaranteed (only some cameras provide the extra metadata), you can't just assume every pair of cameras has one video device and one metadata device. But we can use `v4l2-ctl` to get the device capabilities, and check directly if `Video Capture` is listed. 

`v4l2-ctl` returns both the device's `Capabilities` and it's `Device Caps`. When a device is split into both video and metadata devices, both devices show `Video Capture` as part of `Capabilities`, but only the video device has `Video Capture` as part of `Device Caps`. So I've set the check to first see if `Device Caps` is listed. If it is, check for the `Video Capture` attribute there. If it there are no `Device Caps` (they are optional in the spec), then we can check the `Capabilties` directly. If the parsing logic fails, I've chosen to assume the camera has video capabilities, guessing it is better to sometimes show an incorrect camera than to skip correct cameras.

## Current Behavior

Two webcams are plugged in, one through USB and one attached to the display. But 4 indices are returned. 0 and 2 are valid, but 1 and 3 cannot be opened by cv2.

Enumerate using CAP_ANY backend:
+-------+---------------------------------+------+------+-------------+
| index |               name              | vid  | pid  |     path    |
+-------+---------------------------------+------+------+-------------+
|  1803 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video3 |
|  1802 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|  1801 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video1 |
|  1800 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
|   203 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video3 |
|   202 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|   201 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video1 |
|   200 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
+-------+---------------------------------+------+------+-------------+
Enumerate using GSTREAMER backend:
+-------+---------------------------------+------+------+-------------+
| index |               name              | vid  | pid  |     path    |
+-------+---------------------------------+------+------+-------------+
|     3 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video3 |
|     2 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|     1 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video1 |
|     0 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
+-------+---------------------------------+------+------+-------------+
Enumerate using V4L2 backend:
+-------+---------------------------------+------+------+-------------+
| index |               name              | vid  | pid  |     path    |
+-------+---------------------------------+------+------+-------------+
|     3 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video3 |
|     2 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|     1 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video1 |
|     0 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
+-------+---------------------------------+------+------+-------------+


## Fixed Behavior

Two webcams are plugged in, and only two show for each backend. Using any given device index will work with cv2.

Enumerate using 0 backend:
+-------+---------------------------------+------+------+-------------+
| index |               name              | vid  | pid  |     path    |
+-------+---------------------------------+------+------+-------------+
|  1802 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|  1800 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
|   202 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|   200 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
+-------+---------------------------------+------+------+-------------+
Enumerate using 1800 backend:
+-------+---------------------------------+------+------+-------------+
| index |               name              | vid  | pid  |     path    |
+-------+---------------------------------+------+------+-------------+
|     2 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|     0 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
+-------+---------------------------------+------+------+-------------+
Enumerate using 200 backend:
+-------+---------------------------------+------+------+-------------+
| index |               name              | vid  | pid  |     path    |
+-------+---------------------------------+------+------+-------------+
|     2 | FaceTime HD Camera (Display): F | 05AC | 1112 | /dev/video2 |
|     0 |          USB Camera: USB Camera | 0C45 | 6366 | /dev/video0 |
+-------+---------------------------------+------+------+-------------+
