### PR TITLE
Remove unsupported desk view camera enumeration (MacOs)

### DIFF
--- a/cv2_enumerate_cameras/macos_backend.py
+++ b/cv2_enumerate_cameras/macos_backend.py
@@ -34,10 +34,6 @@ def cameras_generator(apiPreference):
         if hasattr(AVFoundation, "AVCaptureDeviceTypeContinuityCamera"):
             device_types.append(AVFoundation.AVCaptureDeviceTypeContinuityCamera)
 
-        # Add Desk View Camera if available (macOS 13.0+)
-        if hasattr(AVFoundation, "AVCaptureDeviceTypeDeskViewCamera"):
-            device_types.append(AVFoundation.AVCaptureDeviceTypeDeskViewCamera)
-
         device_discovery_session = AVFoundation.AVCaptureDeviceDiscoverySession
         discovery_session = device_discovery_session.discoverySessionWithDeviceTypes_mediaType_position_(
             device_types,


### PR DESCRIPTION
Reason for removing:
- MacOs' desk view camera does not work with OpenCV
- When enumerating desk view cameras, it affects the indices of other connected cameras that actually work, causing them to be out of index